### PR TITLE
Articles-tags

### DIFF
--- a/src/components/ArticleLayout.tsx
+++ b/src/components/ArticleLayout.tsx
@@ -12,6 +12,7 @@ type ArticleLayoutProps = {
     title: string
     description: string
     date: string
+    tags?: string[]
   }
   isRssFeed?: boolean
   previousPathname?: string
@@ -41,7 +42,6 @@ export const ArticleLayout: FC<ArticleLayoutProps> = ({
   meta,
   isRssFeed = false,
   previousPathname,
-  tags = [],
 }) => {
   const router = useRouter()
 
@@ -49,7 +49,10 @@ export const ArticleLayout: FC<ArticleLayoutProps> = ({
     return children
   }
 
-  const uniqueTags = [...new Set(tags)]
+  const uniqueTags = [...new Set(meta.tags ?? [])].map((tagLabel) => ({
+    label: tagLabel,
+    active: false,
+  }))
 
   const handleTagClicked = async (tagId: string) => {
     const urlEncodedTagId = encodeURIComponent(tagId)

--- a/src/components/ArticleLayout.tsx
+++ b/src/components/ArticleLayout.tsx
@@ -5,6 +5,7 @@ import { FC } from "react"
 import { Container } from "@/components/Container"
 import { Prose } from "@/components/Prose"
 import { formatDate } from "@/lib/formatDate"
+import { Tag, Tags } from "./Tags"
 
 type ArticleLayoutProps = {
   meta: {
@@ -15,6 +16,7 @@ type ArticleLayoutProps = {
   isRssFeed?: boolean
   previousPathname?: string
   children: React.ReactNode
+  tags?: string[]
 }
 
 type ArrowLeftIconProps = {
@@ -39,11 +41,19 @@ export const ArticleLayout: FC<ArticleLayoutProps> = ({
   meta,
   isRssFeed = false,
   previousPathname,
+  tags = [],
 }) => {
   const router = useRouter()
 
   if (isRssFeed) {
     return children
+  }
+
+  const uniqueTags = [...new Set(tags)]
+
+  const handleTagClicked = async (tagId: string) => {
+    const urlEncodedTagId = encodeURIComponent(tagId)
+    await router.push(`/articles?tags=${urlEncodedTagId}`)
   }
 
   return (
@@ -79,6 +89,7 @@ export const ArticleLayout: FC<ArticleLayoutProps> = ({
                 </time>
               </header>
               <Prose className="mt-8">{children}</Prose>
+              <Tags tags={uniqueTags} onTagClick={handleTagClicked} />
             </article>
           </div>
         </div>

--- a/src/components/Tags.tsx
+++ b/src/components/Tags.tsx
@@ -52,7 +52,7 @@ export const Tags: FC<{
   if (tags.length === 0) return null
 
   return (
-    <div className={clsx("flex flex-wrap space-x-3", className)}>
+    <div className={clsx("flex flex-wrap gap-x-3 gap-y-3", className)}>
       {tags.map((tag) => (
         <Tag
           key={tag.label}

--- a/src/components/Tags.tsx
+++ b/src/components/Tags.tsx
@@ -1,0 +1,45 @@
+import clsx from "clsx"
+import { FC } from "react"
+
+type TagProps = {
+  className?: string
+  children?: React.ReactNode
+  label: string
+  onClick?: (tagId: string) => void
+}
+
+export const Tag: FC<TagProps> = ({ children, className, label, onClick }) => {
+  const handleTagClick = () => {
+    if (onClick) {
+      onClick(label)
+    }
+  }
+
+  return (
+    <span
+      onClick={handleTagClick}
+      className={clsx(
+        "inline-flex items-center rounded-md bg-blue-400/10 px-2 py-1 text-xs font-medium text-blue-400 ring-1 ring-inset ring-blue-400/30",
+        onClick && "cursor-pointer",
+        className
+      )}
+    >
+      {children ?? label}
+    </span>
+  )
+}
+
+export const Tags: FC<{
+  tags: string[]
+  onTagClick?: (tagId: string) => void
+}> = ({ tags, onTagClick }) => {
+  if (tags.length === 0) return null
+
+  return (
+    <div className="flex flex-wrap space-x-3">
+      {tags.map((tag) => (
+        <Tag key={tag} label={tag} onClick={onTagClick} />
+      ))}
+    </div>
+  )
+}

--- a/src/components/Tags.tsx
+++ b/src/components/Tags.tsx
@@ -5,10 +5,22 @@ type TagProps = {
   className?: string
   children?: React.ReactNode
   label: string
+  active?: boolean
   onClick?: (tagId: string) => void
 }
 
-export const Tag: FC<TagProps> = ({ children, className, label, onClick }) => {
+type Tag = {
+  label: string
+  active: boolean
+}
+
+export const Tag: FC<TagProps> = ({
+  children,
+  className,
+  label,
+  active,
+  onClick,
+}) => {
   const handleTagClick = () => {
     if (onClick) {
       onClick(label)
@@ -19,7 +31,10 @@ export const Tag: FC<TagProps> = ({ children, className, label, onClick }) => {
     <span
       onClick={handleTagClick}
       className={clsx(
-        "inline-flex items-center rounded-md bg-blue-400/10 px-2 py-1 text-xs font-medium text-blue-400 ring-1 ring-inset ring-blue-400/30",
+        "inline-flex items-center rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset",
+        active
+          ? "bg-green-500/10 text-green-400 ring-green-500/20"
+          : "bg-blue-400/10 text-blue-400  ring-blue-400/30",
         onClick && "cursor-pointer",
         className
       )}
@@ -30,7 +45,7 @@ export const Tag: FC<TagProps> = ({ children, className, label, onClick }) => {
 }
 
 export const Tags: FC<{
-  tags: string[]
+  tags: Tag[]
   onTagClick?: (tagId: string) => void
 }> = ({ tags, onTagClick }) => {
   if (tags.length === 0) return null
@@ -38,7 +53,12 @@ export const Tags: FC<{
   return (
     <div className="flex flex-wrap space-x-3">
       {tags.map((tag) => (
-        <Tag key={tag} label={tag} onClick={onTagClick} />
+        <Tag
+          key={tag.label}
+          label={tag.label}
+          active={tag.active}
+          onClick={onTagClick}
+        />
       ))}
     </div>
   )

--- a/src/components/Tags.tsx
+++ b/src/components/Tags.tsx
@@ -46,12 +46,13 @@ export const Tag: FC<TagProps> = ({
 
 export const Tags: FC<{
   tags: Tag[]
+  className?: string
   onTagClick?: (tagId: string) => void
-}> = ({ tags, onTagClick }) => {
+}> = ({ tags, className, onTagClick }) => {
   if (tags.length === 0) return null
 
   return (
-    <div className="flex flex-wrap space-x-3">
+    <div className={clsx("flex flex-wrap space-x-3", className)}>
       {tags.map((tag) => (
         <Tag
           key={tag.label}

--- a/src/pages/articles/index.tsx
+++ b/src/pages/articles/index.tsx
@@ -1,7 +1,9 @@
 import Head from "next/head"
 
+import { useRouter } from "next/router"
 import { Card } from "@/components/Card"
 import { SimpleLayout } from "@/components/SimpleLayout"
+import { Tags } from "@/components/Tags"
 import { formatDate } from "@/lib/formatDate"
 import { getAllArticles } from "@/lib/getAllArticles"
 
@@ -10,10 +12,50 @@ type TArticle = {
   description: string
   date: string
   slug: string
+  tags?: string[]
 }
 
 type ArticleProps = {
   article: TArticle
+}
+
+type Tag = {
+  label: string
+  active: boolean
+}
+
+const getTagsFromQuery = (
+  queryTags: string | string[] | undefined
+): string[] | null => {
+  if (!queryTags) return null
+
+  if (typeof queryTags === "string") return [queryTags]
+
+  return queryTags
+}
+
+const useQueryTags = (tags: string[]): Tag[] => {
+  const router = useRouter()
+
+  const queryTags = getTagsFromQuery(router.query.tags)
+
+  if (!queryTags) return tags.map((tag) => ({ label: tag, active: false }))
+
+  return tags.map((tag) => ({
+    label: tag,
+    active: queryTags.includes(tag),
+  }))
+}
+
+const useArticleFilter = (rawArticles: TArticle[], tags: Tag[]): TArticle[] => {
+  const activeTags = tags.filter((tag) => tag.active).map((tag) => tag.label)
+
+  if (activeTags.length === 0) return rawArticles
+
+  // Filter articles by tag
+  return rawArticles.filter((article) =>
+    article.tags?.some((articleTag) => activeTags.includes(articleTag))
+  )
 }
 
 function Article({ article }: ArticleProps) {
@@ -45,7 +87,29 @@ function Article({ article }: ArticleProps) {
   )
 }
 
-export default function ArticlesIndex({ articles }: { articles: TArticle[] }) {
+export default function ArticlesIndex({
+  articles: rawArticles,
+  tags: rawTags,
+}: {
+  articles: TArticle[]
+  tags: string[]
+}) {
+  const router = useRouter()
+  const tags = useQueryTags(rawTags)
+  const articles = useArticleFilter(rawArticles, tags)
+
+  const handleTagClicked = async (tagId: string) => {
+    const tags = getTagsFromQuery(router.query.tags) ?? []
+    const hasTag = tags.includes(tagId)
+    const newTags = hasTag
+      ? tags.filter((tag) => tag !== tagId)
+      : [...tags, tagId]
+
+    await router.replace({
+      query: { ...router.query, tags: newTags },
+    })
+  }
+
   return (
     <>
       <Head>
@@ -59,6 +123,7 @@ export default function ArticlesIndex({ articles }: { articles: TArticle[] }) {
         title="Writing on software design, company building, and the aerospace industry."
         intro="All of my long-form thoughts on programming, leadership, product design, and more, collected in chronological order."
       >
+        <Tags tags={tags} onTagClick={handleTagClicked} />
         <div className="md:border-l md:border-zinc-100 md:pl-6 md:dark:border-zinc-700/40">
           <div className="flex max-w-3xl flex-col space-y-16">
             {articles.map((article) => (
@@ -72,10 +137,15 @@ export default function ArticlesIndex({ articles }: { articles: TArticle[] }) {
 }
 
 export async function getStaticProps() {
+  const articles = (await getAllArticles()).map(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    ({ component, ...meta }) => meta
+  )
+  const tags = articles.flatMap((article) => article.tags ?? [])
   return {
     props: {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      articles: (await getAllArticles()).map(({ component, ...meta }) => meta),
+      articles,
+      tags,
     },
   }
 }

--- a/src/pages/articles/index.tsx
+++ b/src/pages/articles/index.tsx
@@ -123,7 +123,6 @@ export default function ArticlesIndex({
         title="Writing on software design, company building, and the aerospace industry."
         intro="All of my long-form thoughts on programming, leadership, product design, and more, collected in chronological order."
       >
-        <Tags tags={tags} onTagClick={handleTagClicked} />
         <div className="md:border-l md:border-zinc-100 md:pl-6 md:dark:border-zinc-700/40">
           <div className="flex max-w-3xl flex-col space-y-16">
             {articles.map((article) => (
@@ -131,6 +130,7 @@ export default function ArticlesIndex({
             ))}
           </div>
         </div>
+        <Tags tags={tags} onTagClick={handleTagClicked} className="mt-16" />
       </SimpleLayout>
     </>
   )

--- a/src/pages/articles/index.tsx
+++ b/src/pages/articles/index.tsx
@@ -24,6 +24,8 @@ type Tag = {
   active: boolean
 }
 
+const CLEAR_ALL_TAG = Object.freeze({ label: "Clear all", active: false })
+
 const getTagsFromQuery = (
   queryTags: string | string[] | undefined
 ): string[] | null => {
@@ -41,10 +43,15 @@ const useQueryTags = (tags: string[]): Tag[] => {
 
   if (!queryTags) return tags.map((tag) => ({ label: tag, active: false }))
 
-  return tags.map((tag) => ({
+  const tagsWithFlags = tags.map((tag) => ({
     label: tag,
     active: queryTags.includes(tag),
   }))
+
+  const hasActiveTags = tagsWithFlags.some((tag) => tag.active)
+  if (hasActiveTags) tagsWithFlags.push(CLEAR_ALL_TAG)
+
+  return tagsWithFlags
 }
 
 const useArticleFilter = (rawArticles: TArticle[], tags: Tag[]): TArticle[] => {
@@ -99,6 +106,15 @@ export default function ArticlesIndex({
   const articles = useArticleFilter(rawArticles, tags)
 
   const handleTagClicked = async (tagId: string) => {
+    // Clear all tags if the user clicks on the "Clear all" tag
+    if (tagId === CLEAR_ALL_TAG.label) {
+      await router.replace({
+        query: { ...router.query, tags: [] },
+      })
+      return
+    }
+
+    // Toggle the tag and leave the rest as they are
     const tags = getTagsFromQuery(router.query.tags) ?? []
     const hasTag = tags.includes(tagId)
     const newTags = hasTag

--- a/src/pages/articles/index.tsx
+++ b/src/pages/articles/index.tsx
@@ -141,7 +141,9 @@ export async function getStaticProps() {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     ({ component, ...meta }) => meta
   )
-  const tags = articles.flatMap((article) => article.tags ?? [])
+  const allTags = articles.flatMap((article) => article.tags ?? [])
+  const tags = [...new Set(allTags)] // Remove duplicates
+
   return {
     props: {
       articles,

--- a/src/pages/articles/introducing-animaginary.mdx
+++ b/src/pages/articles/introducing-animaginary.mdx
@@ -1,21 +1,22 @@
-import { ArticleLayout } from '@/components/ArticleLayout'
+import { ArticleLayout } from "@/components/ArticleLayout"
 
 export const meta = {
-  author: 'Adam Wathan',
-  date: '2022-09-02',
-  title: 'Introducing Animaginary: High performance web animations',
+  author: "Adam Wathan",
+  date: "2022-09-02",
+  title: "Introducing Animaginary: High performance web animations",
   description:
-    'When you’re building a website for a company as ambitious as Planetaria, you need to make an impression. I wanted people to visit our website and see animations that looked more realistic than reality itself.',
+    "When you’re building a website for a company as ambitious as Planetaria, you need to make an impression. I wanted people to visit our website and see animations that looked more realistic than reality itself.",
+  tags: ["Animaginary", "WebAssembly", "Web Animations API"],
 }
 
-export default (props) => <ArticleLayout meta={meta} {...props} />
+export default (props) => <ArticleLayout {...{ meta }} {...props} />
 
 When you’re building a website for a company as ambitious as Planetaria, you need to make an impression. I wanted people to visit our website and see animations that looked more realistic than reality itself.
 
 To make this possible, we needed to squeeze every drop of performance out of the browser possible. And so Animaginary was born.
 
 ```js
-import { animate } from '@planetaria/animaginary'
+import { animate } from "@planetaria/animaginary"
 
 export function MyComponent({ open, children }) {
   return (

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2015",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Description
This PR adds several improvements to the articles page:
- Tags have been added to the page, allowing users to filter articles by tag.
- A tag filter has been added to the main article page.
- A "remove all tags" button has been added to the tag filter.
- Tags are now included in the URL query parameters, allowing users to share filtered views of the article list.

## Changes
- Added tags to articles page
- Added tag filter to main article page
- Added "remove all tags" button
- Added tags filter to URL

## Screenshots
N/A

## Testing
Only manual test
- Tested tag filtering functionality
- Tested "remove all tags" button
- Tested URL query parameter handling

## Related PRs
N/A

## Todos
N/A

## Deploy Notes
N/A

## Steps to Test
1. Go to the articles page
2. Click on a tag to filter articles by that tag
3. Click on the same tag to remove the filter
4. Click on the "remove all tags" button to remove all filters
5. Share the URL with tags in the query parameters to see filtered views of the article list

## Impacted Areas in Application
- Articles page