### PR TITLE
feat: config github markdown and prism highlighter

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,12 +1,15 @@
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const withMDX = require("@next/mdx")({
+import rehypePrism from "@mapbox/rehype-prism"
+import mdx from "@next/mdx"
+import remarkGfm from "remark-gfm"
+
+const withMDX = mdx({
   extension: /\.mdx?$/,
   options: {
     // If you use remark-gfm, you'll need to use next.config.mjs
     // as the package is ESM only
     // https://github.com/remarkjs/remark-gfm#install
-    remarkPlugins: [],
-    rehypePlugins: [],
+    remarkPlugins: [remarkGfm],
+    rehypePlugins: [rehypePrism],
     // If you use `MDXProvider`, uncomment the following line.
     // providerImportSource: "@mdx-js/react",
   },
@@ -22,4 +25,4 @@ const nextConfig = {
 }
 
 // Merge MDX config with Next.js config
-module.exports = withMDX(nextConfig)
+export default withMDX(nextConfig)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,7 +33,8 @@
     "**/*.tsx",
     ".next/types/**/*.ts",
     "types.d.ts",
-    "tailwind.config.js"
+    "tailwind.config.js",
+    "next.config.mjs"
   ],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Description
This PR adds several improvements to the rendering of Markdown files in the repository:
- The Github Markdown plugin has been configured to improve the rendering of Markdown files.
- The Prism highlighter has been configured to improve the syntax highlighting of code blocks in Markdown files.

## Changes
- Configured Github Markdown plugin
- Configured Prism highlighter

## Screenshots
N/A

## Testing
- Tested rendering of Markdown files before and after configuration
- Tested syntax highlighting of code blocks in Markdown files before and after configuration

## Related PRs
N/A

## Todos
N/A

## Deploy Notes
N/A

## Steps to Test
1. Open a Markdown file with code blocks in the repository
2. Observe the rendering of the file before and after the configuration
3. Observe the syntax highlighting of the code blocks before and after the configuration

## Impacted Areas in Application
- Rendering of Markdown files
- Syntax highlighting of code blocks in Markdown files